### PR TITLE
Use FlyCheck formatter, fix off-by-one line numbers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ export const provideLinter = () => ({
     let results
     const messages = []
     while((results = regex.exec(output)) !== null) {
-      const lineNumber = parseInt(results[1])
-      const lineColumn = parseInt(results[2])
+      const lineNumber = parseInt(results[1], 10)
+      const lineColumn = parseInt(results[2], 10)
       const severity = results[3] === 'E' ? 'error' : 'warning'
       const message = results[4]
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export const provideLinter = () => ({
   name: 'Dogma',
   grammarScopes: ['source.elixir'],
   scope: 'file',
-  lintsOnChange: true,
+  lintsOnChange: false,
   lint: async (textEditor) => {
     filePath = textEditor.getPath()
     const output = await helpers.exec(

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export const provideLinter = () => ({
     let results
     const messages = []
     while((results = regex.exec(output)) !== null) {
-      const lineNumber = parseInt(results[1], 10)
+      const lineNumber = parseInt(results[1], 10) - 1
       const lineColumn = parseInt(results[2], 10)
       const severity = results[3] === 'E' ? 'error' : 'warning'
       const message = results[4]

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export const provideLinter = () => ({
     const messages = []
     while((results = regex.exec(output)) !== null) {
       const lineNumber = parseInt(results[1], 10) - 1
-      const lineColumn = parseInt(results[2], 10)
+      const lineColumn = parseInt(results[2], 10) - 1
       const severity = results[3] === 'E' ? 'error' : 'warning'
       const message = results[4]
 


### PR DESCRIPTION
Quick tweak to extract more granular data about linting results with the FlyCheck formatter (I tried JSON but it didn't seem to work on my machine) and fix the line number drift.